### PR TITLE
Add support for format:2 transaction data

### DIFF
--- a/view.js
+++ b/view.js
@@ -39,9 +39,22 @@ function show_mail (txid) {
             previous_page.style.display = 'block'
         }
 
-        var mail =
-			arweave.utils.bufferToString(
-			    await decrypt_mail(arweave.utils.b64UrlToBuffer(tx.data), key))
+        var mail = {};
+
+        switch (tx.format) {
+            case 1:
+                mail = arweave.utils.bufferToString(
+                    await decrypt_mail(arweave.utils.b64UrlToBuffer(tx.data), key))
+                break;
+            case 2:
+                var data = await arweave.transactions.getData(txid)
+                mail = await arweave.utils.bufferToString(
+                    await decrypt_mail(arweave.utils.b64UrlToBuffer(data), key)
+                )
+                break;
+            default:
+                throw new Error(`Unexpected transaction format: ${tx.format}`);
+        }
 
         try {
             mail = JSON.parse(mail);


### PR DESCRIPTION
Arweave introduced a new format for transaction data but the weavemail app hasn't kept up.

Currently it is unable to view messages stored using the new transaction data format. 

This PR adds support for `format:2` transaction data and enables weavemail app to view messages again.

The behavior I'm observing is sometimes the weavemail transactions arrive with their `txn.data` field initialized and sometimes they don't.  In the cases where `.data` is uninitialized the app isn't able to display the message.  You'll see an error in the log about `b64UrlToBuffer()` unable to perform a `.replace` on the argument data because it's not a string.

This behavior is intermittent, some days the txn's have `.data` initialized sometimes they require `.getData()`. 

![image](https://user-images.githubusercontent.com/3269261/130661963-5107f91d-9379-44ab-9e7c-34c030b694ef.png)
![image](https://user-images.githubusercontent.com/3269261/130664509-983ee4cd-18ec-4238-ab80-3b6bb164c9bf.png)
![image](https://user-images.githubusercontent.com/3269261/130664531-5c56c77d-009f-4186-be3d-68d4173feb47.png)
